### PR TITLE
add simple auth/security demo

### DIFF
--- a/demoapp/security.py
+++ b/demoapp/security.py
@@ -1,0 +1,21 @@
+
+from zope.interface import implements
+from repoze.who.interfaces import IAuthenticator
+
+
+class DummyAuthenticator(object):
+    """Authenticator that accepts any and all login credentials."""
+    implements(IAuthenticator)
+    def authenticate(self, environ, identity):
+        return identity.get("login")
+
+
+def forbidden_view(request):
+    """Custom "forbidden" view for pyramid.
+
+    This will use the repoze.who challenge API to prompt for credentials.
+    We should submit such a view upstream to pyramid_who.
+    """
+    api = request.environ.get("repoze.who.api")
+    return request.get_response(api.challenge())
+

--- a/demoapp/views.py
+++ b/demoapp/views.py
@@ -1,3 +1,7 @@
+
+from pyramid.exceptions import Forbidden
+from pyramid.security import authenticated_userid
+
 from demoapp import api
 
 
@@ -6,3 +10,11 @@ def hello(request):
     """ Blah.
     """
     return {'Hello': 'World'}
+
+@api(pattern='/{username}/secret', renderer='json', method='GET')
+def secret(request):
+    username = authenticated_userid(request)
+    if request.matchdict["username"] != username:
+        raise Forbidden()
+    return {"username": username}
+

--- a/dev-reqs.txt
+++ b/dev-reqs.txt
@@ -14,3 +14,5 @@ zope.component == 3.11
 zope.deprecation == 3.5
 zope.event == 3.5.1
 zope.interface == 3.8
+pyramid_who == 0.2
+repoze.who == 2.0

--- a/etc/who.ini
+++ b/etc/who.ini
@@ -1,0 +1,27 @@
+[plugin:basicauth]
+use = repoze.who.plugins.basicauth:make_plugin
+realm = 'Sync'
+
+[plugin:dummyauth]
+use = demoapp.security:DummyAuthenticator
+
+[general]
+request_classifier = repoze.who.classifiers:default_request_classifier
+challenge_decider = repoze.who.classifiers:default_challenge_decider
+remote_user_key = REMOTE_USER
+
+[identifiers]
+plugins =
+      basicauth
+
+[authenticators]
+plugins =
+      dummyauth
+
+[challengers]
+plugins =
+      basicauth
+
+[mdproviders]
+plugins =
+


### PR DESCRIPTION
This is a simple integration with repoze.who for view security.

It's not using pyramid's permission system yet, we need to think about how the permission/resource/ACL system might (or might not) map onto the kinds of view security we typically need.
